### PR TITLE
update shipstation service

### DIFF
--- a/app/services/shipstation/create_order.rb
+++ b/app/services/shipstation/create_order.rb
@@ -5,7 +5,7 @@ module Shipstation
     attr_reader :params, :base_url, :api_key, :api_secret, :company_name
 
     def initialize(order_params, company_id)
-      @params = order_params['order'].to_unsafe_h.deep_symbolize_keys[:payload][:order]
+      @params = order_params['order'].to_unsafe_h.deep_symbolize_keys
       @company_name = Company.find(company_id)&.name
 
       integration_setting = IntegrationSetting.find_by(company_id: company_id)


### PR DESCRIPTION
rollback a change:

this code work when you re try a webhook
```rb
@params = order_params['order'].to_unsafe_h.deep_symbolize_keys[:payload][:order]
```

and this other work in std flow
```rb
@params = order_params['order'].to_unsafe_h.deep_symbolize_keys
```